### PR TITLE
Add config for hiding database info

### DIFF
--- a/src/main/java/red/jackf/chesttracker/config/ChestTrackerConfig.java
+++ b/src/main/java/red/jackf/chesttracker/config/ChestTrackerConfig.java
@@ -48,6 +48,7 @@ public class ChestTrackerConfig implements ConfigData {
         public int columnCount = 9;
         public boolean hideDeleteButton = false;
         public boolean enableButton = true;
+        public boolean hideDatabaseInfo = false;
     }
 
     public static class DatabaseOptions {

--- a/src/main/java/red/jackf/chesttracker/gui/ItemListScreen.java
+++ b/src/main/java/red/jackf/chesttracker/gui/ItemListScreen.java
@@ -248,13 +248,15 @@ public class ItemListScreen extends CottonClientScreen {
 
                 showAll.setOnClick(() -> ChestTracker.startRenderingForLocations(database.getAllMemories(currentWorld)));
 
-                // Dimension Label
-                WLabel dimensionLabel = new WLabel(new LiteralText(currentWorld.toString()));
-                settingsPanel.add(dimensionLabel, BEVEL_PADDING, height - BEVEL_PADDING - 12);
-
-                // Database name
-                WLabel databaseName = new WLabel(new LiteralText(database.getId()));
-                settingsPanel.add(databaseName, BEVEL_PADDING, height - BEVEL_PADDING, 80, 12);
+                if (!ChestTracker.CONFIG.visualOptions.hideDatabaseInfo) {
+                    // Dimension Label
+                    WLabel dimensionLabel = new WLabel(new LiteralText(currentWorld.toString()));
+                    settingsPanel.add(dimensionLabel, BEVEL_PADDING, height - BEVEL_PADDING - 12);
+    
+                    // Database name
+                    WLabel databaseName = new WLabel(new LiteralText(database.getId()));
+                    settingsPanel.add(databaseName, BEVEL_PADDING, height - BEVEL_PADDING, 80, 12);
+                }
 
                 // Set tab
                 if (selectedTabIndex == -1) {


### PR DESCRIPTION
The primary desire for wanting this addition is the ability to hide server IP addresses specifically, as currently, the UI displays it due to it being used as the database ID. This is not at all ideal when streaming on a private server with this mod installed. If you feel that dimension info should be persistent or should have its own config I am happy to update this pull request!