### PR TITLE
Make mod setting for displayContainerNames override memorybank setting

### DIFF
--- a/src/client/java/red/jackf/chesttracker/impl/rendering/NameRenderer.java
+++ b/src/client/java/red/jackf/chesttracker/impl/rendering/NameRenderer.java
@@ -19,7 +19,7 @@ public class NameRenderer {
     public static void setup() {
         WorldRenderEvents.BEFORE_BLOCK_OUTLINE.register((context, hitResult) -> {
             MemoryBankAccessImpl.INSTANCE.getLoadedInternal().ifPresent(bank -> {
-                if (!bank.getMetadata().getCompatibilitySettings().displayContainerNames)
+                if (!bank.getMetadata().getCompatibilitySettings().displayContainerNames || !ChestTrackerConfig.INSTANCE.instance().rendering.displayContainerNames)
                     return;
                 bank.getKey(ProviderUtils.getPlayersCurrentKey()).ifPresent(key -> NameRenderer.renderNamesForKey(context, bank, key));
             });


### PR DESCRIPTION
After installing this mod, I realized that the setting for displayContainerNames doesn't work. It seems that the memorybank setting for the same option overrides it. This pr makes it the other way around, which, in my opinion, is more intuitive, since, a player who has configured this mod _after_ joining a server/world would expect the config option to do something and not be useless until they create a new world.