### PR TITLE
configurable litematica search radius

### DIFF
--- a/src/client/java/red/jackf/chesttracker/impl/config/ChestTrackerConfig.java
+++ b/src/client/java/red/jackf/chesttracker/impl/config/ChestTrackerConfig.java
@@ -136,6 +136,9 @@ public class ChestTrackerConfig {
             @SerialEntry
             public boolean countNearbyMaterials = false;
 
+            @SerialEntry
+            public int searchradius = 48;
+
             public boolean anyEnabled() {
                 return materialListSearchButtons || countNearbyMaterials || countEnderChestMaterials;
             }

--- a/src/client/java/red/jackf/chesttracker/impl/config/ChestTrackerConfigScreenBuilder.java
+++ b/src/client/java/red/jackf/chesttracker/impl/config/ChestTrackerConfigScreenBuilder.java
@@ -509,6 +509,15 @@ public class ChestTrackerConfigScreenBuilder {
                                 )
                                 .build()
                         )
+                        .option(Option.<Integer>createBuilder()
+                                .name(translatable("chesttracker.config.gui.searchradius"))
+                                .controller(opt -> IntegerSliderControllerBuilder.create(opt)
+                                        .range(4, 64)
+                                        .step(1))
+                                .binding(instance.defaults().gui.itemListTextScale,
+                                        () -> instance.instance().compatibility.litematica.searchradius,
+                                        i -> instance.instance().compatibility.litematica.searchradius = i)
+                                .build())
                         .build())
                 .build();
     }

--- a/src/client/java/red/jackf/chesttracker/mixins/compat/litematica/MaterialListUtilsMixin.java
+++ b/src/client/java/red/jackf/chesttracker/mixins/compat/litematica/MaterialListUtilsMixin.java
@@ -41,7 +41,7 @@ public abstract class MaterialListUtilsMixin {
 
                 if (config.countNearbyMaterials) {
                     ProviderUtils.getPlayersCurrentKey().ifPresent(currentKey -> {
-                        for (ItemStack stack : bank.getCounts(currentKey, CountingPredicate.within(player.position(), 48), StackMergeMode.ALL, true)) {
+                        for (ItemStack stack : bank.getCounts(currentKey, CountingPredicate.within(player.position(), config.searchradius), StackMergeMode.ALL, true)) {
                             inventoryStacks.addTo(new ItemType(stack, true, false), stack.getCount());
                         }
                     });

--- a/src/client/resources/assets/chesttracker/lang/en_us.json
+++ b/src/client/resources/assets/chesttracker/lang/en_us.json
@@ -191,6 +191,7 @@
   "chesttracker.config.compatibility.wthit": "WTHIT Integration",
   "chesttracker.config.compatibility.wthit.description": "Allows you to use the current Memory Bank to show highlights in WTHIT. There are additional settings under the WTHIT's plugin manager.",
   "chesttracker.config.compatibility.litematica": "Litematica",
+  "chesttracker.config.gui.compatibility.litematica.searchradius": "Radius of blocks for Chest tracker to search",
   "chesttracker.config.compatibility.litematica.materialListSearchButtons": "Add Search Buttons to Material List",
   "chesttracker.config.compatibility.litematica.countEnderChestMaterials": "Count Ender Chest Materials",
   "chesttracker.config.compatibility.litematica.countEnderChestMaterials.description": "Whether to add materials in your Ender Chest to Litematica's material calculations.",


### PR DESCRIPTION
tired of building under my base with chest tracker indexing base chests,inconvenient to go to the base to get the resource

i didnt add the radius value in the material tab of litematica,lazy